### PR TITLE
Update zviahel records

### DIFF
--- a/data/101/752/933/101752933.geojson
+++ b/data/101/752/933/101752933.geojson
@@ -20,124 +20,136 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":8.0,
-    "name:azb_x_preferred":[
+    "name:azb_x_historical":[
         "\u0646\u0648\u0648\u0648\u0647\u0631\u0627\u062f-\u0648\u0648\u0644\u06cc\u0646\u0633\u06a9\u06cc\u06cc"
     ],
-    "name:bel_x_preferred":[
+    "name:bel_x_historical":[
         "\u041d\u0430\u0432\u0430\u0433\u0440\u0430\u0434-\u0412\u0430\u043b\u044b\u043d\u0441\u043a\u0456"
     ],
-    "name:bul_x_preferred":[
+    "name:bul_x_historical":[
         "\u041d\u043e\u0432\u043e\u0433\u0440\u0430\u0434 \u0412\u043e\u043b\u0438\u043d\u0441\u043a\u0438"
     ],
-    "name:ceb_x_preferred":[
+    "name:ceb_x_historical":[
         "Novohrad-Volyns'kyy"
     ],
-    "name:ces_x_preferred":[
+    "name:ces_x_historical":[
         "Novohrad-Volynskyj"
     ],
-    "name:chv_x_preferred":[
+    "name:chv_x_historical":[
         "\u041d\u043e\u0432\u0433\u043e\u0440\u043e\u0434-\u0412\u043e\u043b\u044b\u043d\u0441\u043a\u0438"
     ],
-    "name:crh_x_preferred":[
+    "name:crh_x_historical":[
         "Novograd-Vol\u0131nsk\u0131y"
     ],
-    "name:cym_x_preferred":[
+    "name:cym_x_historical":[
         "Novohrad-Volynskyi"
     ],
-    "name:deu_x_preferred":[
+    "name:deu_x_historical":[
         "Nowohrad-Wolynskyj"
     ],
     "name:eng_x_preferred":[
-        "Novohrad-Volynskyi"
-    ],
-    "name:fas_x_preferred":[
-        "\u0646\u0648\u0648\u0648\u0647\u0631\u0627\u062f-\u0648\u0648\u0644\u06cc\u0646\u0633\u06a9\u06cc\u06cc"
-    ],
-    "name:fin_x_preferred":[
-        "Novohrad-Volynskyi"
-    ],
-    "name:fra_x_preferred":[
-        "Novohrad-Volynsky\u00ef"
-    ],
-    "name:heb_x_preferred":[
-        "\u05e0\u05d5\u05d1\u05d5\u05d4\u05e8\u05d3-\u05d5\u05d5\u05dc\u05d9\u05e0\u05e1\u05e7\u05d9"
-    ],
-    "name:hsb_x_preferred":[
-        "Nowohrad-Wolynskyj"
-    ],
-    "name:hye_x_preferred":[
-        "\u0546\u0578\u057e\u0578\u0563\u0580\u0561\u0564-\u054e\u0578\u056c\u056b\u0576\u057d\u056f\u056b"
-    ],
-    "name:ita_x_preferred":[
-        "Novohrad-Volyns'kyj"
-    ],
-    "name:jpn_x_preferred":[
-        "\u30ce\u30f4\u30a9\u30d5\u30e9\u30fc\u30c9\u30fb\u30f4\u30a9\u30eb\u30a3\u30fc\u30f3\u30b7\u30af\u30a3\u30a4"
-    ],
-    "name:kat_x_preferred":[
-        "\u10dc\u10dd\u10d5\u10dd\u10d2\u10e0\u10d0\u10d3-\u10d5\u10dd\u10da\u10d8\u10dc\u10e1\u10d9\u10d8"
-    ],
-    "name:kor_x_preferred":[
-        "\ub178\ubcf4\ud750\ub77c\ub4dc\ubcfc\ub9b0\uc2a4\ud0a4"
-    ],
-    "name:lav_x_preferred":[
-        "Novohrada-Volinska"
-    ],
-    "name:lit_x_preferred":[
-        "Voluin\u0117s Naugardas"
-    ],
-    "name:nld_x_preferred":[
-        "Novohrad-Volynskyi"
-    ],
-    "name:nno_x_preferred":[
-        "Novohrad-Volynskyj"
-    ],
-    "name:nob_x_preferred":[
-        "Novohrad-Volynskyj"
-    ],
-    "name:pol_x_preferred":[
-        "Nowogr\u00f3d Wo\u0142y\u0144ski"
-    ],
-    "name:por_x_preferred":[
-        "Novohrad-Volinski"
-    ],
-    "name:ron_x_preferred":[
-        "Novohrad-Vol\u00eensk\u00eei"
-    ],
-    "name:rus_x_preferred":[
-        "\u041d\u043e\u0432\u043e\u0433\u0440\u0430\u0434-\u0412\u043e\u043b\u044b\u043d\u0441\u043a\u0438\u0439"
-    ],
-    "name:sah_x_preferred":[
-        "\u041d\u043e\u0432\u043e\u0433\u0440\u0430\u0434-\u0412\u043e\u043b\u044b\u043d\u0441\u043a\u0438\u0439"
+        "Zviahel"
     ],
     "name:spa_x_preferred":[
+        "Zviahel"
+    ],
+    "name:ukr_x_preferred":[
+        "Звягель"
+    ],
+    "name:rus_x_preferred":[
+        "Звягель"
+    ],
+    "name:eng_x_historical":[
         "Novohrad-Volynskyi"
     ],
-    "name:srp_x_preferred":[
-        "\u041d\u043e\u0432\u043e\u0433\u0440\u0430\u0434-\u0412\u043e\u043b\u0438\u043d\u0441\u043a\u0438"
+    "name:fas_x_historical":[
+        "\u0646\u0648\u0648\u0648\u0647\u0631\u0627\u062f-\u0648\u0648\u0644\u06cc\u0646\u0633\u06a9\u06cc\u06cc"
     ],
-    "name:swe_x_preferred":[
+    "name:fin_x_historical":[
+        "Novohrad-Volynskyi"
+    ],
+    "name:fra_x_historical":[
+        "Novohrad-Volynsky\u00ef"
+    ],
+    "name:heb_x_historical":[
+        "\u05e0\u05d5\u05d1\u05d5\u05d4\u05e8\u05d3-\u05d5\u05d5\u05dc\u05d9\u05e0\u05e1\u05e7\u05d9"
+    ],
+    "name:hsb_x_historical":[
+        "Nowohrad-Wolynskyj"
+    ],
+    "name:hye_x_historical":[
+        "\u0546\u0578\u057e\u0578\u0563\u0580\u0561\u0564-\u054e\u0578\u056c\u056b\u0576\u057d\u056f\u056b"
+    ],
+    "name:ita_x_historical":[
+        "Novohrad-Volyns'kyj"
+    ],
+    "name:jpn_x_historical":[
+        "\u30ce\u30f4\u30a9\u30d5\u30e9\u30fc\u30c9\u30fb\u30f4\u30a9\u30eb\u30a3\u30fc\u30f3\u30b7\u30af\u30a3\u30a4"
+    ],
+    "name:kat_x_historical":[
+        "\u10dc\u10dd\u10d5\u10dd\u10d2\u10e0\u10d0\u10d3-\u10d5\u10dd\u10da\u10d8\u10dc\u10e1\u10d9\u10d8"
+    ],
+    "name:kor_x_historical":[
+        "\ub178\ubcf4\ud750\ub77c\ub4dc\ubcfc\ub9b0\uc2a4\ud0a4"
+    ],
+    "name:lav_x_historical":[
+        "Novohrada-Volinska"
+    ],
+    "name:lit_x_historical":[
+        "Voluin\u0117s Naugardas"
+    ],
+    "name:nld_x_historical":[
+        "Novohrad-Volynskyi"
+    ],
+    "name:nno_x_historical":[
         "Novohrad-Volynskyj"
     ],
-    "name:tat_x_preferred":[
+    "name:nob_x_historical":[
+        "Novohrad-Volynskyj"
+    ],
+    "name:pol_x_historical":[
+        "Nowogr\u00f3d Wo\u0142y\u0144ski"
+    ],
+    "name:por_x_historical":[
+        "Novohrad-Volinski"
+    ],
+    "name:ron_x_historical":[
+        "Novohrad-Vol\u00eensk\u00eei"
+    ],
+    "name:rus_x_historical":[
+        "\u041d\u043e\u0432\u043e\u0433\u0440\u0430\u0434-\u0412\u043e\u043b\u044b\u043d\u0441\u043a\u0438\u0439"
+    ],
+    "name:sah_x_historical":[
+        "\u041d\u043e\u0432\u043e\u0433\u0440\u0430\u0434-\u0412\u043e\u043b\u044b\u043d\u0441\u043a\u0438\u0439"
+    ],
+    "name:spa_x_historical":[
+        "Novohrad-Volynskyi"
+    ],
+    "name:srp_x_historical":[
+        "\u041d\u043e\u0432\u043e\u0433\u0440\u0430\u0434-\u0412\u043e\u043b\u0438\u043d\u0441\u043a\u0438"
+    ],
+    "name:swe_x_historical":[
+        "Novohrad-Volynskyj"
+    ],
+    "name:tat_x_historical":[
         "\u041d\u043e\u0432\u043e\u0433\u0440\u0430\u0434-\u0412\u043e\u043b\u044b\u043d\u0441\u043a\u0438\u0439"
     ],
     "name:tat_x_variant":[
         "\u041d\u043e\u0432\u043e\u04bb\u0440\u0430\u0434-\u0412\u043e\u043b\u044b\u043d\u0441\u043a\u044b\u0439"
     ],
-    "name:ukr_x_preferred":[
+    "name:ukr_x_historical":[
         "\u041d\u043e\u0432\u043e\u0433\u0440\u0430\u0434-\u0412\u043e\u043b\u0438\u043d\u0441\u044c\u043a\u0438\u0439"
     ],
     "name:und_x_variant":[
         "Zwiahl"
     ],
-    "name:vie_x_preferred":[
+    "name:vie_x_historical":[
         "Novohrad-Volynskyi"
     ],
-    "name:yid_x_preferred":[
+    "name:yid_x_historical":[
         "\u05d6\u05d5\u05d5\u05e2\u05d4\u05d9\u05dc"
     ],
-    "name:zho_x_preferred":[
+    "name:zho_x_historical":[
         "\u6c83\u502b\u65af\u57fa\u65b0\u57ce"
     ],
     "qs:a0":"\u0423\u043a\u0440\u0430\u0457\u043d\u0430",
@@ -171,7 +183,7 @@
         "gp:id":928799,
         "qs_pg:id":128421,
         "wd:id":"Q149024",
-        "wk:page":"Novohrad-Volynskyi"
+        "wk:page":"Zviahel"
     },
     "wof:country":"UA",
     "wof:geomhash":"8546f4ac1fa022ac51435539c526b796",
@@ -186,14 +198,14 @@
     ],
     "wof:id":101752933,
     "wof:lastmodified":1566593186,
-    "wof:name":"\u041d\u043e\u0432\u043e\u0433\u0440\u0430\u0434-\u0412\u043e\u043b\u0438\u043d\u0441\u044c\u043a\u0438\u0439",
+    "wof:name":"Zviahel",
     "wof:parent_id":1108815943,
     "wof:placetype":"locality",
     "wof:population":55925,
     "wof:population_rank":8,
     "wof:repo":"whosonfirst-data-admin-ua",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[1126011667],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/112/601/166/7/1126011667.geojson
+++ b/data/112/601/166/7/1126011667.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2022-01-12",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -19,7 +20,7 @@
     "lbl:max_zoom":14.0,
     "lbl:min_zoom":9.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":1,
+    "mz:is_current":0,
     "mz:min_zoom":8.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:azb_x_preferred":[
@@ -197,7 +198,7 @@
     "wof:population":55925,
     "wof:population_rank":8,
     "wof:repo":"whosonfirst-data-admin-ua",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[101752933],
     "wof:supersedes":[],
     "wof:tags":[]
 },


### PR DESCRIPTION
https://www.wikidata.org/wiki/Q149024

WOF has three records for "Novohrad-Volynskyi" - one region and two localities.

Region: https://spelunker.whosonfirst.org/id/1108815763/
Locality: https://spelunker.whosonfirst.org/id/1126011667/
Locality: https://spelunker.whosonfirst.org/id/101752933/

The city was renamed in Nov. 2022 to "Zviahel", though the name of the region has yet to be changed. This PR:
 - Supersedes the point locality into the polygon locality, flagging the point locality as not current
 - Moves all of the existing names of the polygon locality to "_x_historical" names
 - Adds new English, Spanish, Russian, and Ukranian "preferred" names to the kept record

This PR doesn't require PIP work, it just cleans up the records for this city and adjusts names.