### PR TITLE
Updated preferred name for Dnipro in latin-script languages.

### DIFF
--- a/data/101/752/861/101752861.geojson
+++ b/data/101/752/861/101752861.geojson
@@ -147,7 +147,7 @@
         "Dnipropetrovsk"
     ],
     "name:eng_x_preferred":[
-        "Dnipropetrovs'k"
+        "Dnipro"
     ],
     "name:eng_x_variant":[
         "Dnipropetrovsk",

--- a/data/101/752/861/101752861.geojson
+++ b/data/101/752/861/101752861.geojson
@@ -124,11 +124,11 @@
     "name:dan_x_preferred":[
         "Dnipro"
     ],
-    "name:deu_x_preferred":[
-        "Dnipro"
-    ],
     "name:deu_x_variant":[
-        "Dnipro"
+        "Dnipropetrowsk"
+    ],
+    "name:deu_x_historical":[
+        "Dnipropetrowsk"
     ],
     "name:dsb_x_preferred":[
         "Dnipro"
@@ -152,6 +152,9 @@
     "name:eng_x_variant":[
         "Dnipropetrovsk",
         "Dnipro"
+    ],
+    "name:eng_x_historical":[
+        "Dnipropetrovs'k"
     ],
     "name:epo_x_preferred":[
         "Dnipro"
@@ -408,7 +411,10 @@
         "Dnipro"
     ],
     "name:msa_x_variant":[
-        "Dnipro"
+        "Dnipropetrovsk"
+    ],
+    "name:msa_x_historical":[
+        "Dnipropetrovsk"
     ],
     "name:mya_x_preferred":[
         "\u1014\u1036\u1015\u102b\u1010\u103a\u101c\u102d\u102f\u101c\u102c\u1038\u101e\u1030"
@@ -429,7 +435,10 @@
         "Dnipro"
     ],
     "name:nob_x_variant":[
-        "Dnipro"
+        "Dnipropetrovsk"
+    ],
+    "name:nob_x_historical":[
+        "Dnipropetrovsk"
     ],
     "name:nor_x_preferred":[
         "Dnipro"
@@ -473,7 +482,10 @@
         "Dnipro"
     ],
     "name:por_x_variant":[
-        "Dnipro"
+        "Dnipropetrovsk"
+    ],
+    "name:por_x_historical":[
+        "Dnipropetrovsk"
     ],
     "name:pus_x_preferred":[
         "\u0689\u0646\u067e\u0631\u0648"
@@ -529,7 +541,10 @@
         "Dnipro"
     ],
     "name:slv_x_variant":[
-        "Dnipro"
+        "Dnepropetrovsk"
+    ],
+    "name:slv_x_historical":[
+        "Dnepropetrovsk"
     ],
     "name:smo_x_preferred":[
         "Dnipro"
@@ -549,6 +564,10 @@
     "name:spa_x_preferred":[
         "Dnipro"
     ],
+    "name:spa_x_historical":[
+        "Dnipropetrovsk"
+    ],
+
     "name:spa_x_variant":[
         "Dnipr\u00f3"
     ],

--- a/data/101/752/861/101752861.geojson
+++ b/data/101/752/861/101752861.geojson
@@ -124,6 +124,9 @@
     "name:dan_x_preferred":[
         "Dnipro"
     ],
+    "name:deu_x_preferred":[
+        "Dnipro"
+    ],
     "name:deu_x_variant":[
         "Dnipropetrowsk"
     ],

--- a/data/101/752/861/101752861.geojson
+++ b/data/101/752/861/101752861.geojson
@@ -128,7 +128,7 @@
         "Dnipro"
     ],
     "name:deu_x_variant":[
-        "Dnipropetrowsk"
+        "Dnipro"
     ],
     "name:dsb_x_preferred":[
         "Dnipro"
@@ -405,7 +405,7 @@
         "Dnipro"
     ],
     "name:msa_x_preferred":[
-        "Dnipropetrovsk"
+        "Dnipro"
     ],
     "name:msa_x_variant":[
         "Dnipro"
@@ -426,7 +426,7 @@
         "Dnipro"
     ],
     "name:nob_x_preferred":[
-        "Dnipropetrovsk"
+        "Dnipro"
     ],
     "name:nob_x_variant":[
         "Dnipro"
@@ -470,7 +470,7 @@
         "Dnipro"
     ],
     "name:por_x_preferred":[
-        "Dnipropetrovsk"
+        "Dnipro"
     ],
     "name:por_x_variant":[
         "Dnipro"
@@ -526,7 +526,7 @@
         "Dnepropetrovsk"
     ],
     "name:slv_x_preferred":[
-        "Dnipropetrovsk"
+        "Dnipro"
     ],
     "name:slv_x_variant":[
         "Dnipro"
@@ -547,7 +547,7 @@
         "Dnipro"
     ],
     "name:spa_x_preferred":[
-        "Dnipropetrovsk"
+        "Dnipro"
     ],
     "name:spa_x_variant":[
         "Dnipr\u00f3"

--- a/data/101/752/861/101752861.geojson
+++ b/data/101/752/861/101752861.geojson
@@ -130,9 +130,6 @@
     "name:deu_x_variant":[
         "Dnipropetrowsk"
     ],
-    "name:deu_x_historical":[
-        "Dnipropetrowsk"
-    ],
     "name:dsb_x_preferred":[
         "Dnipro"
     ],


### PR DESCRIPTION
The name of the city has changed from Dnipropetrovsk to Dnipro -> updated the eng preferred name to reflect that.

Source: https://en.wikipedia.org/wiki/Dnipro

_To comply with the [2015 decommunization law](https://en.wikipedia.org/wiki/Decommunization_in_Ukraine) the city was renamed Dnipro in May 2016, after the river that flows through the city.[[21]](https://en.wikipedia.org/wiki/Dnipro#cite_note-drbvr-21)[[19]](https://en.wikipedia.org/wiki/Dnipro#cite_note-decommupbbcU-19)_
