### PR TITLE
Update Medvedka

### DIFF
--- a/data/132/688/637/5/1326886375.geojson
+++ b/data/132/688/637/5/1326886375.geojson
@@ -2,8 +2,10 @@
   "id": 1326886375,
   "type": "Feature",
   "properties": {
+    "date:inception_lower":"1600-01-01",
+    "date:inception_upper":"1600-12-31",
     "edtf:cessation":"uuuu",
-    "edtf:inception":"uuuu",
+    "edtf:inception":"1600",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"28.45989,49.38191,28.45989,49.38191",
@@ -27,13 +29,16 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
     "name:bul_x_preferred":[
         "\u041c\u0435\u0434\u0432\u0435\u0434\u043a\u0430"
     ],
     "name:che_x_preferred":[
         "\u041c\u0435\u0434\u0432\u0435\u0434\u043a\u0430"
+    ],
+    "name:eng_x_colloquial":[
+        "Medvidka"
     ],
     "name:hye_x_preferred":[
         "\u0544\u0565\u0564\u057e\u0565\u0564\u056f\u0561"
@@ -45,8 +50,8 @@
     "wof:belongsto":[
         102191581,
         85633805,
-        85688783,
-        1108815611
+        1108815611,
+        85688783
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -64,10 +69,21 @@
         }
     ],
     "wof:id":1326886375,
-    "wof:lastmodified":1566591102,
-    "wof:name":"Medvedka",
+    "wof:lang_x_official":[
+        "ukr"
+    ],
+    "wof:lang_x_spoken":[
+        "ukr",
+        "rus"
+    ],
+    "wof:lastmodified":1747468443,
+    "wof:name":"Medvidka",
     "wof:parent_id":1108815611,
     "wof:placetype":"locality",
+    "wof:placetype_alt":[
+        "\u041c\u0435\u0434\u0432\u0456\u0434\u043a\u0430"
+    ],
+    "wof:population":400,
     "wof:repo":"whosonfirst-data-admin-ua",
     "wof:superseded_by":[],
     "wof:supersedes":[],


### PR DESCRIPTION
Replaces https://github.com/whosonfirst-data/whosonfirst-data-admin-ua/pull/31. https://github.com/whosonfirst-data/whosonfirst-data-admin-ua/pull/32, and https://github.com/whosonfirst-data/whosonfirst-data-admin-ua/pull/33

Adds inception date, a wikidata concordance, population data, lang properties, and adjusts names for the locality of Medvedka.

Number of features updated: 1